### PR TITLE
Adding potential missing dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(name='scibiomart',
               'scibiomart = scibiomart.__main__:main'
           ]
       },
-      install_requires=['pandas', 'numpy', 'sciutil'],
+      install_requires=['pandas', 'numpy', 'sciutil', 'xmltodict'],
       python_requires='>=3.6',
       data_files=[("", ["LICENSE"])]
       )


### PR DESCRIPTION
Added a dependency, which made importing of scibiomart fail on an Ubuntu 18.04 derived Jupyter container (see https://github.com/jupyter/docker-stacks)

```python
import pandas as pd
from scibiomart import SciBiomartApi, SciBiomart
```

yields an Exception stating that xmltodict is missing.

You may want to crosscheck that.